### PR TITLE
Feature: Enable Binance Sandbox Mode via Environment Variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ OPENROUTER_API_KEY="xxx"
 EXA_API_KEY="xxx"
 BINANCE_API_KEY="xxx"
 BINANCE_API_SECRET="xxx"
+BINANCE_USE_SANDBOX="true"
 DATABASE_URL="postgresql://postgres:root@localhost:5432/xxx"
 CRON_SECRET_KEY="xxxx"
 START_MONEY=30

--- a/.env.production
+++ b/.env.production
@@ -4,6 +4,7 @@ OPENROUTER_API_KEY="xxx"
 EXA_API_KEY="xxx"
 BINANCE_API_KEY="xxx"
 BINANCE_API_SECRET="xxx"
+BINANCE_USE_SANDBOX="false"
 DATABASE_URL="postgresql://postgres:root@localhost:5432/xxx"
 CRON_SECRET_KEY="xxxx"
 START_MONEY=30

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This open-source implementation currently focuses on running the **DeepSeek** tr
    # Trading (Binance)
    BINANCE_API_KEY="your_binance_api_key"
    BINANCE_API_SECRET="your_binance_secret"
+   BINANCE_USE_SANDBOX="true"  # Set to "false" for live trading
    
    # Trading Configuration
    START_MONEY=10000  # Initial capital in USDT (e.g., 10000 = $10,000 USDT)

--- a/lib/trading/biance.ts
+++ b/lib/trading/biance.ts
@@ -7,3 +7,5 @@ export const binance = new ccxt.binance({
     defaultType: "future",
   },
 });
+
+binance.setSandboxMode(process.env.BINANCE_USE_SANDBOX === "true");


### PR DESCRIPTION
This change introduces a configurable way to enable **Binance sandbox mode** through the `BINANCE_USE_SANDBOX` environment variable.

When `BINANCE_USE_SANDBOX=true`, the Binance client will automatically switch to **sandbox mode** using `ccxt`’s built-in support.

####  Implementation

```ts
import ccxt from "ccxt";

export const binance = new ccxt.binance({
  apiKey: process.env.BINANCE_API_KEY,
  secret: process.env.BINANCE_API_SECRET,
  options: {
    defaultType: "future",
  },
});

binance.setSandboxMode(process.env.BINANCE_USE_SANDBOX === "true");
```

#### Environment

Add the new variable to `.env` and `.env.example`:

```bash
# Binance API
BINANCE_API_KEY=xxxx
BINANCE_API_SECRET=xxxx
BINANCE_USE_SANDBOX=true
```

####  Documentation

Updated:

* [.env.example](https://github.com/Bound3R/open-nof1.ai/blob/cc68e7f3941a5ac79830099204ba86ebe224ccdc/.env.example#L7)
* `README.md` (Environment Variables section)

#### ✅ Summary

* Enables sandbox mode toggle via `BINANCE_USE_SANDBOX`.
* Improves developer flexibility between production and testnet environments.
* Maintains backward compatibility.