### PR TITLE
fix: replace hardcoded invocation count with dynamic invocationCount

### DIFF
--- a/lib/ai/prompt.ts
+++ b/lib/ai/prompt.ts
@@ -51,16 +51,21 @@ interface UserPromptOptions {
   currentMarketState: MarketState;
   accountInformationAndPerformance: AccountInformationAndPerformance;
   startTime: Date;
+  invocationCount?: number;
 }
 
 export function generateUserPrompt(options: UserPromptOptions) {
-  const { currentMarketState, accountInformationAndPerformance, startTime } =
-    options;
+  const {
+    currentMarketState,
+    accountInformationAndPerformance,
+    startTime,
+    invocationCount = 0,
+  } = options;
   return `
 It has been ${dayjs(new Date()).diff(
     startTime,
     "minute"
-  )} minutes since you started trading. The current time is ${new Date().toISOString()} and you've been invoked 2011 times. Below, we are providing you with a variety of state data, price data, and predictive signals so you can discover alpha. Below that is your current account information, value, performance, positions, etc.
+  )} minutes since you started trading. The current time is ${new Date().toISOString()} and you've been invoked ${invocationCount} times. Below, we are providing you with a variety of state data, price data, and predictive signals so you can discover alpha. Below that is your current account information, value, performance, positions, etc.
 
 ALL OF THE PRICE OR SIGNAL DATA BELOW IS ORDERED: OLDEST → NEWEST
 

--- a/lib/ai/run.ts
+++ b/lib/ai/run.ts
@@ -14,10 +14,14 @@ export async function run(initialCapital: number) {
   const currentMarketState = await getCurrentMarketState("BTC/USDT");
   const accountInformationAndPerformance =
     await getAccountInformationAndPerformance(initialCapital);
+  // Count previous Chat entries to provide an invocation counter in the prompt
+  const invocationCount = await prisma.chat.count();
+
   const userPrompt = generateUserPrompt({
     currentMarketState,
     accountInformationAndPerformance,
     startTime: new Date(),
+    invocationCount,
   });
 
   const { object, reasoning } = await generateObject({


### PR DESCRIPTION
This PR adds an invocation counter to the user prompt generation flow.

### Changes
- Added `invocationCount` field to `UserPromptOptions` interface.
- Updated `generateUserPrompt` to include the current invocation count in the generated text.
- Updated `run` function to fetch invocation count from Prisma before generating the prompt.

### Context
This helps track how many times the system has been invoked for better monitoring and debugging.

Related to issue #5